### PR TITLE
Fix validation riset#274

### DIFF
--- a/components/Todos/AddTask.vue
+++ b/components/Todos/AddTask.vue
@@ -17,6 +17,7 @@
                   <!-- タスク入力エリア -->
                   <v-col cols="12" sm="6" md="6">
                     <v-text-field
+                      ref="title"
                       v-model="task.title"
                       label="タスクを入力する"
                       prepend-inner-icon="mdi-pencil-outline"
@@ -104,6 +105,16 @@ export default {
       dateMenu: false
     }
   },
+  computed: {
+    createTask: {
+      get() {
+        return this.task
+      },
+      set(createTask) {
+        this.$emit('update:create-task', createTask)
+      }
+    }
+  },
   methods: {
     async handleAddTask() {
       const task = this.task
@@ -119,7 +130,9 @@ export default {
     },
     closeAddTask() {
       this.$emit('close-add-task')
-      this.$refs.form.reset()
+      this.$refs.title.reset()
+      this.createTask.detail = ''
+      this.createTask.date = new Date().toISOString().substr(0, 10)
     },
     ...mapActions('modules/todos', ['addTask'])
   }

--- a/components/Todos/UpdateTask.vue
+++ b/components/Todos/UpdateTask.vue
@@ -122,11 +122,9 @@ export default {
       this.closeUpdateTask()
     },
     closeUpdateTask() {
-      this.$refs.form.reset()
       this.$emit('close-update-task')
     },
     cancelUpdateTask() {
-      this.$refs.form.reset()
       this.$emit('cancel-update-task')
     },
     ...mapActions('modules/todos', ['fetchTodos', 'updateTask'])

--- a/pages/Todos.vue
+++ b/pages/Todos.vue
@@ -10,7 +10,7 @@
       </v-flex>
       <v-flex>
         <AddTask
-          :task="task"
+          :create-task.sync="task"
           :task-dialog="taskDialog"
           @open-add-task="openAddTask"
           @close-add-task="closeAddTask"


### PR DESCRIPTION
タスク追加後にバリデーションリセットを行うと、nullになるため必須項目以外が送信されるとエラーになるので修正。
タスク更新画面を閉じる時は必要ないので削除